### PR TITLE
Update Generator.php

### DIFF
--- a/adm/gii/generators/model/Generator.php
+++ b/adm/gii/generators/model/Generator.php
@@ -211,6 +211,14 @@ class Generator extends \yii\gii\Generator
     }
 
     /**
+     * @inheritdoc
+     */
+    public function getTemplatePath()
+    {
+        return __DIR__.'/adm';
+    }
+
+    /**
      * Generates the attribute labels for the specified table.
      * @param \yii\db\TableSchema $table the table schema
      * @return array the generated attribute labels (name => label)


### PR DESCRIPTION
The default template path uses Yii2 basic model.php, that has another params than yours. As result the new models creation is broken.
